### PR TITLE
Different rendering for overlapping events (v3 vs v4)

### DIFF
--- a/src/timegrid/TimeGridEventRenderer.ts
+++ b/src/timegrid/TimeGridEventRenderer.ts
@@ -222,7 +222,7 @@ export default class TimeGridEventRenderer extends FgEventRenderer {
       } else {
 
         // sort highest pressure first
-        this.sortForwardSegs(forwardSegs)
+        forwardSegs = this.sortForwardSegs(forwardSegs)
 
         // this segment's forwardCoord will be calculated from the backwardCoord of the
         // highest-pressure forward segment.


### PR DESCRIPTION
Here Codepen examples with same set up in v3 and v4:
https://codepen.io/swiod/pen/RzxrLm?editors=0010
https://codepen.io/swiod/pen/EBoPZo?editors=0010

Due to missing assignment of (none in-place) sorted segments coordinates are not computed correctly.